### PR TITLE
Fix image to show as cover instead of cropped

### DIFF
--- a/src/components/hero-banner/hero-header.jsx
+++ b/src/components/hero-banner/hero-header.jsx
@@ -1,39 +1,43 @@
-import React from "react";
-import StyledHeroHeader from "./style";
-import carouselImage from '../../assets/LIVING ROOM - FLIP.jpg'
-import { CarouselProvider, Slider, Slide, ButtonBack, ButtonNext } from 'pure-react-carousel';
+import { CarouselProvider, Slide, Slider } from 'pure-react-carousel';
 import 'pure-react-carousel/dist/react-carousel.es.css';
+import React from 'react';
+import carouselImage from '../../assets/LIVING ROOM - FLIP.jpg';
+import StyledHeroHeader from './style';
 
+const HeroHeader = () => {
+  return (
+    <StyledHeroHeader className="hero-header">
+      <CarouselProvider
+        naturalSlideWidth={100}
+        naturalSlideHeight={75}
+        totalSlides={2}
+        visibleSlides={1}
+        isPlaying
+        infinite
+        isIntrinsicHeight
+      >
+        <Slider className="carousel__slider">
+          <Slide
+            index={0}
+            className="carousel__slider__slides"
+          >
+            <picture>
+              <img src={carouselImage} />
+            </picture>
+          </Slide>
 
-  const HeroHeader = () => {
-    return (
-      <StyledHeroHeader className="hero-header">
-        <CarouselProvider
-          naturalSlideWidth={100}
-          naturalSlideHeight={75}
-          totalSlides={2}
-          visibleSlides={1}
-          isPlaying
-          infinite
-          isIntrinsicHeight
-         >
-          <Slider className="carousel__slider">
-            <Slide index={0} className="carousel__slider__slides">
-              <picture>
-                <img src={carouselImage} />
-              </picture>
-            </Slide>
-
-            <Slide index={1}>
-              <picture>
-                <img src={carouselImage} />
-              </picture>
-            </Slide>
-          </Slider>
-        </CarouselProvider>
-      </StyledHeroHeader>
-    );
-  }
-
+          <Slide
+            index={1}
+            className="carousel__slider__slides"
+          >
+            <picture>
+              <img src={carouselImage} />
+            </picture>
+          </Slide>
+        </Slider>
+      </CarouselProvider>
+    </StyledHeroHeader>
+  );
+};
 
 export default HeroHeader;

--- a/src/components/hero-banner/style.jsx
+++ b/src/components/hero-banner/style.jsx
@@ -1,25 +1,31 @@
 import styled from 'styled-components';
 
 const StyledHeroHeader = styled.header`
-    position: fixed;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+
+  &:after {
+    content: '';
+    position: absolute;
     top: 0;
     bottom: 0;
     left: 0;
     right: 0;
     width: 100%;
     height: 100%;
+    background-color: #0000007a;
+  }
 
-    &:after {
-        content: "";
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        width: 100%;
-        height: 100%;
-        background-color: #0000007a;
-    }
+  img {
+    width: 100%;
+    height: 100vh;
+    object-fit: cover;
+  }
 `;
 
 export default StyledHeroHeader;


### PR DESCRIPTION
Fix to prevent images in the hero header from being cropped.

**Example**
<img width="1236" alt="image" src="https://github.com/VishSeen/react-imagine3d/assets/39788411/3e273461-8699-41ff-a6fc-ec778c639daf">
